### PR TITLE
Fixes 'hide_cell/code'

### DIFF
--- a/nbreport/__init__.py
+++ b/nbreport/__init__.py
@@ -62,8 +62,8 @@ def generate_report(ntbk, path_out):
     # Clean up the notebook
     cleaner = NotebookCleaner(ntbk)
     cleaner.remove_cells(empty=True)
-    cleaner.remove_cells(search_text='hide_cell')
-    cleaner.clear(kind="content", search_text='hide_code')
+    cleaner.remove_cells(tag='hide_cell')
+    cleaner.clear(kind="content", tag='hide_code')
     cleaner.clear('stderr')
 
     path_out_tmp = path_out + '_TMP'


### PR DESCRIPTION
This fixes the 'hide_cell' and 'hide_code' functionality (issue #4) by
changing 'search_text=' to 'tag=' in the NotebookClearner call.

This was tested with  `nbclean==0.3.2`